### PR TITLE
refactor(enemies): move logic from level to enemies

### DIFF
--- a/src/datastruct/vector.hpp
+++ b/src/datastruct/vector.hpp
@@ -152,5 +152,12 @@ namespace datastruct {
 
             return *this;
         }
+
+        int indexOf(T el) {
+            for (unsigned int i = 0; i < size_; i++) {
+                if (data_[i] == el) return i;
+            }
+            return -1;
+        }
     };
 };  // namespace datastruct

--- a/src/entities/enemy.fwd.h
+++ b/src/entities/enemy.fwd.h
@@ -1,0 +1,4 @@
+#pragma once
+namespace entities {
+    class Enemy;
+}  // namespace entities

--- a/src/entities/enemy.hpp
+++ b/src/entities/enemy.hpp
@@ -2,6 +2,7 @@
 
 #include <mutex>
 
+#include "manager/level.fwd.h"
 #include "collectables/artifact.hpp"
 #include "collectables/power.hpp"
 #include "entities/entity.hpp"
@@ -48,6 +49,6 @@ namespace entities {
 
         bool canMove();
 
-        virtual enums::EnemyType getEnemyType() = 0;
+        virtual bool canAttack(manager::Level *levelManager) = 0;
     };
 }  // namespace entities

--- a/src/entities/entity.cpp
+++ b/src/entities/entity.cpp
@@ -55,7 +55,7 @@ bool Entity::isDead() const {
     return life_ <= 0;
 }
 
-void Entity::attack(Entity *entity) {
+void Entity::attackEntity(Entity *entity) {
     entity->applyDamage(attack_);
 }
 

--- a/src/entities/entity.hpp
+++ b/src/entities/entity.hpp
@@ -34,7 +34,14 @@ class Entity : public Movable, public level::Collidable {
 
     // metodo virtuale che sarà definita a
     // seconda del metodo d'attacco dell'entità
-    virtual void attack(Entity *target);
+    virtual void attackEntity(Entity *target);
+
+    /**
+     * @brief metodo virtuale che implementa ogni genere di attacco per 
+     * tutte le entità
+     */
+    virtual void attack(manager::Level *levelManager) = 0;
+
 
     // muove l'entità secondo la direzione impostata
     void move(manager::Level *levelManager);
@@ -46,6 +53,7 @@ class Entity : public Movable, public level::Collidable {
     void setLife(int life);
 
     int getAttack();
+
 
     virtual enums::CollisionType getCollisionType() override;
 };

--- a/src/entities/kamikaze.cpp
+++ b/src/entities/kamikaze.cpp
@@ -1,16 +1,26 @@
 #include "entities/kamikaze.hpp"
 
-#include <mutex>
-#include <stdlib.h>
-
+#include <cstdlib>  // abs
+#include "manager/level.hpp"
 namespace entities{
     Kamikaze::Kamikaze()
-        : Enemy('K'){}
+        : Enemy('K') {}
     
     Kamikaze::Kamikaze(Position pos)
-        :Enemy(pos, 7, 'K'){}
+        : Enemy(pos, 7, 'K') {}
     
-    enums::EnemyType Kamikaze::getEnemyType(){
-        return enums::EnemyType::KAMIKAZE;
+    void Kamikaze::attack(manager::Level *levelManager) {
+        if (canAttack(levelManager)) {
+            this->attackEntity(levelManager->getPlayer());
+            levelManager->getLogQueue()->addEvent("Il nemico e' esploso");
+            levelManager->getLevel()->deleteCollidable((level::Collidable * ) this);
+        }
     }
+
+    bool Kamikaze::canAttack(manager::Level *levelManager) {
+        Position playerPosition = levelManager->getPlayer()->getPosition();
+        Position currPosition = this->getPosition();
+        return abs(playerPosition.riga - currPosition.riga) <= 1 && abs(playerPosition.colonna - currPosition.colonna);
+    }
+
 }

--- a/src/entities/kamikaze.cpp
+++ b/src/entities/kamikaze.cpp
@@ -20,7 +20,7 @@ namespace entities{
     bool Kamikaze::canAttack(manager::Level *levelManager) {
         Position playerPosition = levelManager->getPlayer()->getPosition();
         Position currPosition = this->getPosition();
-        return abs(playerPosition.riga - currPosition.riga) <= 1 && abs(playerPosition.colonna - currPosition.colonna);
+        return abs(playerPosition.riga - currPosition.riga) <= 1 && abs(playerPosition.colonna - currPosition.colonna) <= 1;
     }
 
 }

--- a/src/entities/kamikaze.hpp
+++ b/src/entities/kamikaze.hpp
@@ -4,6 +4,7 @@
 
 #include "entities/enemy.hpp"
 #include "gamestruct/position.hpp"
+#include "manager/level.fwd.h"
 
 namespace entities {
     class Kamikaze : public Enemy {
@@ -13,6 +14,8 @@ namespace entities {
         Kamikaze();
         Kamikaze(Position spawnPos);
 
-        virtual enums::EnemyType getEnemyType() override;
+        void attack(manager::Level *levelManager) override;
+
+        bool canAttack(manager::Level *levelManager) override;
     };
 }  // namespace entities

--- a/src/entities/player.cpp
+++ b/src/entities/player.cpp
@@ -132,10 +132,6 @@ void Player::attack(manager::Level *levelManager) {
     logger_.debug("next position: %d, %d", bulletPosition.colonna, bulletPosition.riga);
     logger_.debug("curr position: %d, %d", this->getPosition().colonna, this->getPosition().riga);
     level::Collidable *collision = level->getCollision(bulletPosition, levelManager);
-
-    // TODO(simo): check per vedere la collisione istantanea, cioè gestisci questo
-    // caso ad esempio fare danno subito, perché il bullet va a controllare se
-    // la cella in cui vuole andare colpisce qualcosa
     if (collision == nullptr || collision->getCollisionType() == enums::CollisionType::ENTITY) {
         weapon::Bullet *bullet = new weapon::Bullet(bulletPosition, this->getLastNotNullDirection(), this->getAttack());
         level->addBullet(bullet);

--- a/src/entities/player.hpp
+++ b/src/entities/player.hpp
@@ -39,8 +39,6 @@ class Player : public Entity {
     Logger logger_;
 
     virtual void _handleDoorCollision(manager::Level *levelManager, level::DoorSegment *door) override;
-    virtual void _handleWallCollision(manager::Level *levelManager, level::WallSegment *wall) override;
-    virtual void _handleEntityCollision(manager::Level *levelManager, Entity *entity) override;
     virtual void _handleArtifactCollision(manager::Level *levelManager, collectables::Artifact *artifact) override;
     virtual void _handlePowerCollision(manager::Level *levelManager, collectables::Power *power) override;
     virtual void _handleNoneCollision(manager::Level *levelManager) override;
@@ -65,4 +63,6 @@ class Player : public Entity {
     void coolDown();
 
     bool canFire();
+
+    void attack(manager::Level *levelManager) override;
 };

--- a/src/entities/shooter.cpp
+++ b/src/entities/shooter.cpp
@@ -1,16 +1,21 @@
 #include "entities/shooter.hpp"
 
-#include <mutex>
-#include <stdlib.h>
+#include "enums/collision-type.hpp"
+#include "enums/direction.hpp"
+#include "entities/weapon/bullet.hpp"
+#include "level/collidable.hpp"
+#include "manager/level.hpp"
 
 namespace entities{
     Shooter::Shooter()
-        : Enemy('S'){}
+        : Enemy('S'),  // TODO(simo) e shootcool down dove è?
+        logger_("Shooter") {}
     
     Shooter::Shooter(Position pos)
         :Enemy(pos, 3, 'S'),
         shootCoolDown_(0),
-        shootCoolDownMax_(20){}
+        shootCoolDownMax_(20),
+        logger_("Shooter") {}
 
     void Shooter::resetShootCoolDown(){
         shootCoolDown_ = shootCoolDownMax_;
@@ -27,9 +32,90 @@ namespace entities{
         return shootCoolDown_ == 0;
     }
     
-    enums::EnemyType Shooter::getEnemyType(){
-        return enums::EnemyType::SHOOTER;
+    void Shooter::attack(manager::Level *levelManager) {
+        if (!canShoot()) {
+            this->ShootCoolDown();
+            return;
+        }
+
+        level::Collidable *collision;
+        level::Level *level = levelManager->getLevel();
+        Position playerPosition = levelManager->getPlayer()->getPosition();
+        Position currPosition = this->getPosition();
+        bool firable = true;
+
+        // TODO simo, c'è ancora bisogno di migliorare questa parte
+        if(currPosition.riga == playerPosition.riga){
+            if(currPosition.colonna < playerPosition.colonna){
+                for(int i = (currPosition.colonna + 1); i <  (playerPosition.colonna); i++){
+                    collision = level->getCollision(Position(currPosition.riga, i), levelManager);
+                    enums::CollisionType type = enums::CollisionType::NONE;
+                    if (collision != nullptr) type = collision->getCollisionType();
+                    if(type != enums::CollisionType::NONE){
+                        firable = false;
+                    }
+                }
+                if(firable){
+                    this->resetShootCoolDown();
+                    logger_.info("enemy firing a bullet");
+                    Position bulletPosition = Position(currPosition.riga, currPosition.colonna + 1);
+                    weapon::Bullet *bullet = new weapon::Bullet(bulletPosition, enums::Direction::RIGHT, this->getAttack());
+                    level->addBullet(bullet);
+                }
+            }
+            else{
+                for(int i = (currPosition.colonna - 1); i >  (playerPosition.colonna); i--){
+                    collision = level->getCollision(Position (currPosition.riga, i), levelManager);
+                    enums::CollisionType type = enums::CollisionType::NONE;
+                    if (collision != nullptr) type = collision->getCollisionType();
+                    if(type != enums::CollisionType::NONE){
+                        firable = false;
+                    }
+                }
+                if(firable){
+                    this->resetShootCoolDown();
+                    logger_.info("enemy firing a bullet");
+                    Position bulletPosition = Position(currPosition.riga, currPosition.colonna - 1);
+                    weapon::Bullet *bullet = new weapon::Bullet(bulletPosition, enums::Direction::LEFT, this->getAttack());
+                    level->addBullet(bullet);
+                }
+            }
+        }
+        if(currPosition.colonna == playerPosition.colonna){
+            if(currPosition.riga < playerPosition.riga){
+                for(int i = (currPosition.riga + 1); i <  (playerPosition.riga); i++){
+                    collision = level->getCollision(Position (i, currPosition.colonna), levelManager);
+                    enums::CollisionType type = enums::CollisionType::NONE;
+                    if (collision != nullptr) type = collision->getCollisionType();
+                    if(type != enums::CollisionType::NONE){
+                        firable = false;
+                    }
+                }
+                if(firable){
+                    this->resetShootCoolDown();
+                    logger_.info("enemy firing a bullet");
+                    Position bulletPosition = Position(currPosition.riga + 1, currPosition.colonna);
+                    weapon::Bullet *bullet = new weapon::Bullet(bulletPosition, enums::Direction::DOWN, this->getAttack());
+                    level->addBullet(bullet);
+                }
+            }
+            else{
+                for(int i = (currPosition.riga - 1); i >  (playerPosition.riga); i--){
+                    collision = level->getCollision(Position (i, currPosition.colonna), levelManager);
+                    enums::CollisionType type = enums::CollisionType::NONE;
+                    if (collision != nullptr) type = collision->getCollisionType();
+                    if(type != enums::CollisionType::NONE){
+                        firable = false;
+                    }
+                }
+                if(firable){
+                    this->resetShootCoolDown();
+                    logger_.info("enemy firing a bullet");
+                    Position bulletPosition = Position(currPosition.riga - 1, currPosition.colonna);
+                    weapon::Bullet *bullet = new weapon::Bullet(bulletPosition, enums::Direction::UP, this->getAttack());
+                    level->addBullet(bullet);
+                }
+            }
+        }
     }
-
-
 }

--- a/src/entities/shooter.hpp
+++ b/src/entities/shooter.hpp
@@ -2,15 +2,17 @@
 
 #include <mutex>
 
+#include "manager/level.fwd.h"
 #include "entities/enemy.hpp"
 #include "gamestruct/position.hpp"
-
+#include "gamestruct/logger.hpp"
 namespace entities {
     class Shooter : public Enemy {
       private:
         int shootCoolDown_;
         int shootCoolDownMax_;
 
+        Logger logger_;
       public:
         Shooter();
         Shooter(Position spawnPos);
@@ -21,6 +23,10 @@ namespace entities {
 
         bool canShoot();
 
-        virtual enums::EnemyType getEnemyType() override;
+        void attack(manager::Level *levelManager) override;
+
+
+        // TODO simo
+        virtual bool canAttack(manager::Level *levelManager) override {return false;};
     };
 }  // namespace entities

--- a/src/level/level.hpp
+++ b/src/level/level.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "entities/enemy.fwd.h"
 #include "collectables/artifact.hpp"
 #include "collectables/power.hpp"
 #include "datastruct/vector.hpp"
-#include "entities/enemy.hpp"
 #include "entities/shooter.hpp"
 #include "entities/entity.hpp"
 #include "entities/player.hpp"
@@ -51,20 +51,22 @@ namespace level {
         // @returns true se la posizione è vuota, false altrimenti
         bool isPositionEmpty(Position pos, manager::Level *levelManager);
 
-        datastruct::Vector<collectables::Power *> getPowers();
-        datastruct::Vector<collectables::Artifact *> getArtifacts();
-
         void addBullet(weapon::Bullet *bullet);
         void renderBullets(WINDOW *win, manager::Level *levelmanager);
 
-        void deleteEnemy(Collidable *collision, WINDOW *win);
-        void deletePower(int i);
-        void deleteArtifact(int i);
-
-        void enemyShoot(entities::Shooter *s, manager::Level *levelManager);
-        void enemiesAttack(WINDOW *win, manager::Level *levelManager);
         void renderEnemies(WINDOW *win, manager::Level *levelManager);
         // @returns l'oggetto di collisione alla data posizione
         Collidable *getCollision(Position pos, manager::Level *levelManager) const;
+
+        /**
+         * @brief elimina il collidable in input.
+         * presuppone che sia dei seguenti tipi:
+         * - artifact
+         * - power
+         * - enemy
+         * 
+         * E che questi siano presenti nella lista corrispondente in questo oggetto
+         */
+        void deleteCollidable(Collidable *collidable);
     };
 };  // namespace level

--- a/src/loader/objects/enemy.cpp
+++ b/src/loader/objects/enemy.cpp
@@ -6,24 +6,28 @@ namespace loader {
     void Enemy::load(FILE *file) {
         LoadObject::resetTransferred();
 
-        int numeroShooter;
-        fscanf(file, "%d", &numeroShooter);
-        this->loadedObjects_->resize(numeroShooter);
-        for (int i = 0; i < numeroShooter; i++) {
-            Position startPosition;
-            fscanf(file, "%d %d\n", &startPosition.riga, &startPosition.colonna);
-            entities::Enemy *enemy = new entities::Shooter(startPosition);
-            this->loadedObjects_->at(i) = enemy;
-        }
+        // TODO(simo): la roba per decidere che tipo di enemy creare
+        // ossia l'enum enemy type lo puoi utilizzare qui...
+        // anche se non so quanto sia utile utilizzarlo se lo usi qui boh...
         
-        //int numeroKamikaze;
-        //fscanf(file, "%d", &numeroKamikaze);
-        //this->loadedObjects_->resize(numeroKamikaze);
-        //for (int i = 0; i < numeroKamikaze; i++) {
-        //    Position startPosition;
-        //    fscanf(file, "%d %d\n", &startPosition.riga, &startPosition.colonna);
-        //    entities::Enemy *enemy = new entities::Kamikaze(startPosition);
-        //    this->loadedObjects_->at(i) = enemy;
-        //}
+        // int numeroShooter;
+        // fscanf(file, "%d", &numeroShooter);
+        // this->loadedObjects_->resize(numeroShooter);
+        // for (int i = 0; i < numeroShooter; i++) {
+        //     Position startPosition;
+        //     fscanf(file, "%d %d\n", &startPosition.riga, &startPosition.colonna);
+        //     entities::Enemy *enemy = new entities::Shooter(startPosition);
+        //     this->loadedObjects_->at(i) = enemy;
+        // }
+        
+        int numeroKamikaze;
+        fscanf(file, "%d", &numeroKamikaze);
+        this->loadedObjects_->resize(numeroKamikaze);
+        for (int i = 0; i < numeroKamikaze; i++) {
+           Position startPosition;
+           fscanf(file, "%d %d\n", &startPosition.riga, &startPosition.colonna);
+           entities::Enemy *enemy = new entities::Kamikaze(startPosition);
+           this->loadedObjects_->at(i) = enemy;
+        }
     };
 }  // namespace loader

--- a/src/manager/level.cpp
+++ b/src/manager/level.cpp
@@ -63,31 +63,6 @@ namespace manager {
         return levels_[levelIdx_->getCurrent()]->getCollision(pos, levelManager);
     }
 
-    void Level::playerShoot() {
-        if (!player_->canFire()) {
-            return;
-        }
-
-        player_->resetCoolDown();
-        logger_.info("player firing a bullet");
-        Position bulletPosition = player_->getNextPosition();
-        logger_.debug("next position: %d, %d", bulletPosition.colonna, bulletPosition.riga);
-        logger_.debug("curr position: %d, %d", player_->getPosition().colonna, player_->getPosition().riga);
-        level::Collidable *collision = getCollision(bulletPosition, this);
-
-        // BUG: a volte quando il player va troppo veloce, prendere la sua prossima
-        // posizione non è ancora sufficiente per non cancellarlo dallo schermo
-
-        // TODO(simo): check per vedere la collisione istantanea, cioè gestisci questo
-        // caso ad esempio fare danno subito, perché il bullet va a controllare se
-        // la cella in cui vuole andare colpisce qualcosa
-        if (collision == nullptr || collision->getCollisionType() == enums::CollisionType::ENTITY) {
-            weapon::Bullet *bullet = new weapon::Bullet(bulletPosition, player_->getLastNotNullDirection(), player_->getAttack());
-            levels_[levelIdx_->getCurrent()]->addBullet(bullet);
-        }
-        
-    }
-
     void Level::goToLevel(int levelIdx) {
         logger_.info("Loading level with index: %d", levelIdx);
 
@@ -109,7 +84,6 @@ namespace manager {
         }
 
         levels_[levelIdx_->getCurrent()]->renderEnemies(win, this);
-        levels_[levelIdx_->getCurrent()]->enemiesAttack(win, this);
 
         // WARNING: non spostare questo render sotto al player,
         // vogliamo che prima renderizzi i bullets e poi il player

--- a/src/manager/level.hpp
+++ b/src/manager/level.hpp
@@ -56,8 +56,7 @@ namespace manager {
         void goToLevel(int level);
 
         level::Collidable *getCollision(Position pos, manager::Level *levelManager);
-        void playerShoot();
-
+        
         LogQueue *getLogQueue();
 
         void render(WINDOW *win, bool force);

--- a/src/views/game-sub-view.cpp
+++ b/src/views/game-sub-view.cpp
@@ -21,7 +21,7 @@ namespace views {
                 levelManager_->getPlayer()->setDirection(enums::Direction::DOWN);
                 break;
             case 'j':
-                levelManager_->playerShoot();
+                levelManager_->getPlayer()->attack(levelManager_);
                 break;
         }
     }


### PR DESCRIPTION
<!-- 👆 Fornisci un riepilogo generale delle tue modifiche nel titolo sopra  -->

## Descrizione 
<!-- Una descrizione dei cambi che hai fatto -->
1. Spostato tutta la logica per l'attacco dei player nelle corrispettive classi, liberando molte dipendenze in enemies
2. Creato il `deleteCollidable`
3. Ampliato il vector con una nuova funzionalità, utilizzata nel deleteCollidable

## TODOS
migliorare la logica per il Shooter

## Screenshots
<!-- Se si ha lavorato sulla parte grafica può essere comodo avere video o screenshots a riguardo -->