### PR TITLE
refactor(entity): collision handlers

### DIFF
--- a/src/entities/enemy.cpp
+++ b/src/entities/enemy.cpp
@@ -35,7 +35,7 @@ namespace entities {
     void Enemy::setPosition(Position pos) {
         Displayable::setPosition(pos);
     }
-    
+
     void Enemy::resetCoolDown() {
         coolDown_ = coolDownMax_;
     }

--- a/src/entities/enemy.cpp
+++ b/src/entities/enemy.cpp
@@ -35,20 +35,7 @@ namespace entities {
     void Enemy::setPosition(Position pos) {
         Displayable::setPosition(pos);
     }
-    void Enemy::_handleDoorCollision(manager::Level *levelManager, level::DoorSegment *door) {
-    }
-    void Enemy::_handleWallCollision(manager::Level *levelManager, level::WallSegment *wall) {
-    }
-    void Enemy::_handleEntityCollision(manager::Level *levelManager, Entity *entity) {
-    }
-    void Enemy::_handleArtifactCollision(manager::Level *levelManager, collectables::Artifact *artifact) {
-    }
-    void Enemy::_handlePowerCollision(manager::Level *levelManager, collectables::Power *power) {
-    }
-    void Enemy::_handleNoneCollision(manager::Level *levelManager) {
-        this->setPosition(nextPosition_);
-    }
-
+    
     void Enemy::resetCoolDown() {
         coolDown_ = coolDownMax_;
     }

--- a/src/entities/enemy.hpp
+++ b/src/entities/enemy.hpp
@@ -27,12 +27,6 @@ namespace entities {
         int coolDown_;
         int coolDownMax_;
         Logger logger_;
-        virtual void _handleDoorCollision(manager::Level *levelManager, level::DoorSegment *door) override;
-        virtual void _handleWallCollision(manager::Level *levelManager, level::WallSegment *wall) override;
-        virtual void _handleEntityCollision(manager::Level *levelManager, Entity *entity) override;
-        virtual void _handleArtifactCollision(manager::Level *levelManager, collectables::Artifact *artifact) override;
-        virtual void _handlePowerCollision(manager::Level *levelManager, collectables::Power *power) override;
-        virtual void _handleNoneCollision(manager::Level *levelManager) override;
 
       public:
         Enemy(char c);

--- a/src/entities/entity.cpp
+++ b/src/entities/entity.cpp
@@ -32,9 +32,6 @@ void Entity::move(manager::Level *levelManager) {
         case enums::CollisionType::DOORSEGMENT:
             _handleDoorCollision(levelManager, (level::DoorSegment *) collision);
             break;
-        case enums::CollisionType::WALLSEGMENT:
-            _handleWallCollision(levelManager, (level::WallSegment *) collision);
-            break;
         case enums::CollisionType::ENTITY:
             _handleEntityCollision(levelManager, (Entity *) collision);
             break;
@@ -46,6 +43,9 @@ void Entity::move(manager::Level *levelManager) {
             break;
         case enums::CollisionType::NONE:
             _handleNoneCollision(levelManager);
+            break;
+        default:
+            // do nothing
             break;
     }
     nextPosition_ = _computeNextPosition(lastNotNullDirection_);
@@ -85,8 +85,10 @@ void Entity::render(WINDOW *win, bool force) {
 };
 
 void Entity::_handleDoorCollision(manager::Level *levelManager, level::DoorSegment *door) {}
-void Entity::_handleWallCollision(manager::Level *levelManager, level::WallSegment *wall) {}
 void Entity::_handleEntityCollision(manager::Level *levelManager, Entity *entity) {}
 void Entity::_handleArtifactCollision(manager::Level *levelManager, collectables::Artifact *artifact) {}
 void Entity::_handlePowerCollision(manager::Level *levelManager, collectables::Power *power) {}
-void Entity::_handleNoneCollision(manager::Level *levelManager) {}
+
+void Entity::_handleNoneCollision(manager::Level *levelManager) {
+    this->setPosition(nextPosition_);
+}

--- a/src/entities/entity.hpp
+++ b/src/entities/entity.hpp
@@ -16,7 +16,6 @@ class Entity : public Movable, public level::Collidable {
     int attack_;  // danno fatto alle altre entità
 
     virtual void _handleDoorCollision(manager::Level *levelManager, level::DoorSegment *door);
-    virtual void _handleWallCollision(manager::Level *levelManager, level::WallSegment *wall);
     virtual void _handleEntityCollision(manager::Level *levelManager, Entity *entity);
     virtual void _handleArtifactCollision(manager::Level *levelManager, collectables::Artifact *artifact);
     virtual void _handlePowerCollision(manager::Level *levelManager, collectables::Power *power);

--- a/src/entities/player.cpp
+++ b/src/entities/player.cpp
@@ -100,10 +100,6 @@ void Player::_handlePowerCollision(manager::Level *levelManager, collectables::P
     currLevel->deleteCollidable((Collidable *) power);
 }
 
-void Player::_handleNoneCollision(manager::Level *levelManager) {
-    this->setPosition(nextPosition_);
-}
-
 int Player::getScore() {
     return score_;
 }

--- a/src/entities/player.hpp
+++ b/src/entities/player.hpp
@@ -42,7 +42,6 @@ class Player : public Entity {
     virtual void _handleDoorCollision(manager::Level *levelManager, level::DoorSegment *door) override;
     virtual void _handleArtifactCollision(manager::Level *levelManager, collectables::Artifact *artifact) override;
     virtual void _handlePowerCollision(manager::Level *levelManager, collectables::Power *power) override;
-    virtual void _handleNoneCollision(manager::Level *levelManager) override;
 
   public:
     Player();


### PR DESCRIPTION
<!-- 👆 Fornisci un riepilogo generale delle tue modifiche nel titolo sopra  -->

## Descrizione 
Questa PR dovrebbe risolvere questo errore
```
src/entities/entity.cpp:36:71: runtime error: downcast of address 0x60800000aaa0 which does not point to an object of type 'WallSegment'
0x60800000aaa0: note: object is of type 'level::LocalDoor'
 01 00 80 59  a8 35 f7 46 e6 55 00 00  05 00 00 00 19 00 00 00  05 00 00 00 23 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'level::LocalDoor'

=================================================================
==456==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x7f18ab11a090 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc2090)
    #1 0x7f18aaee92aa  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xab2aa)

SUMMARY: AddressSanitizer: 64 byte(s) leaked in 2 allocation(s).
```